### PR TITLE
fix group ID in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Easily create and customize simple ASCII tables in Java. Based off
 Maven:
 ```
 <dependency>
-  <groupId>com.github,freva</groupId>
+  <groupId>com.github.freva</groupId>
   <artifactId>ascii-table</artifactId>
   <version>1.1.0</version>
 </dependency>


### PR DESCRIPTION
This patch fixes the group ID for the Maven dependency declaration in the readme, just to save people copy/pasting the dependency into their `pom.xml` another keystroke.