### PR TITLE
Performance/AsciiTable::writeRepeated

### DIFF
--- a/src/main/java/com/github/freva/asciitable/AsciiTable.java
+++ b/src/main/java/com/github/freva/asciitable/AsciiTable.java
@@ -388,8 +388,7 @@ public class AsciiTable {
     private static void writeRepeated(OutputStreamWriter osw, char c, int num) throws IOException {
         char[] array = new char[num];
         Arrays.fill(array, c);
-        CharBuffer b = CharBuffer.wrap(array);
-        osw.append(b);
+        osw.write(array);
     }
 
     private static @Nullable String[][] objectArrayToString(Column[] columns, @Nullable Object [][] array) {

--- a/src/main/java/com/github/freva/asciitable/AsciiTable.java
+++ b/src/main/java/com/github/freva/asciitable/AsciiTable.java
@@ -7,10 +7,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
+import java.nio.CharBuffer;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -43,7 +41,7 @@ public class AsciiTable {
         if (border.length != NO_BORDERS.length)
             throw new IllegalArgumentException("Border characters array must be exactly " + NO_BORDERS.length + " elements long");
 
-        String[][] stringData = objectArrayToString(rawColumns, data);
+        @Nullable String[][] stringData = objectArrayToString(rawColumns, data);
         int numColumns = getNumColumns(rawColumns, data);
         Column[] columns = IntStream.range(0, numColumns)
                 .mapToObj(index -> index < rawColumns.length ? rawColumns[index] : new Column())
@@ -274,8 +272,13 @@ public class AsciiTable {
     }
 
     private static void writeRepeated(OutputStreamWriter osw, char c, int num) throws IOException {
-        for (int i = 0; i < num; i++) osw.append(c);
+        char[] array = new char[num];
+        Arrays.fill(array, c);
+        CharBuffer b = CharBuffer.wrap(array);
+        osw.append(b);
     }
+
+
 
     private static @Nullable String[][] objectArrayToString(Column[] columns, @Nullable Object [][] array) {
         int[] numInvisible = new int[Math.max(1, columns.length)];

--- a/src/main/java/com/github/freva/asciitable/AsciiTable.java
+++ b/src/main/java/com/github/freva/asciitable/AsciiTable.java
@@ -392,8 +392,6 @@ public class AsciiTable {
         osw.append(b);
     }
 
-
-
     private static @Nullable String[][] objectArrayToString(Column[] columns, @Nullable Object [][] array) {
         int[] numInvisible = new int[Math.max(1, columns.length)];
         for (int i = 0; i < columns.length; i++)


### PR DESCRIPTION
Hello again, this will probably my last pull request for a while since my holiday is over :)

I wanted to familiarize myself with the [Java Microbenchmark Harness (JMH)](https://github.com/openjdk/jmh), so I wrote some [benchmarking code](https://github.com/jp-berg/ascii-table/tree/performance/jmh), profiled the application with the Intellij Profiler and tried various performance enhancements, which I then benchmarked. For each idea I made a new `performance/XXX`-branch in my repository and a branch called `performance/XXX_jmh` where I merged the benchmarking code into the branch to test the performance. 

Long story short - this is the only change I found that:

- unambiguously improves performance
- does not require big rewrites of the codebase

## Benchmarking Environment

Operating System: Kubuntu 25.10
Kernel Version: 6.17.0-20-generic (64-bit)
Processors: AMD Ryzen 5 5600X 6-Core Processor
Memory: 32 GiB of RAM (31,3 GiB usable)
JMH version: 1.37
VM version: JDK 22.0.1, OpenJDK 64-Bit Server VM, 22.0.1+8-16

## Benchmark Description

The benchmark generates a vocabulary of 10000 random words between 3 and 15 characters length. From those words the data for 5000 different tables with headers is generated, each cell holding between 1 and 25 of the random words. The table sizes vary between 2, 4 and 8 columns and 1, 10, 100 and 1000 rows.

The benchmark uses 5 warmup iterations and 5 iterations à 10 seconds for each column-number-row-number-combination. It then measures the throughput.

The border used is `AsciiTable.BASIC_ASCII`, with the `asString()`-method as the table-generation-step.

## Results

### Baseline (https://github.com/jp-berg/ascii-table/tree/performance/jmh)

```
Benchmark                  (numCols)  (numRows)   Mode  Cnt      Score     Error  Units
BenchmarkRunner.benchmark          2          1  thrpt    5  83362.027 ± 861.724  ops/s
BenchmarkRunner.benchmark          2         10  thrpt    5  13659.211 ±  70.377  ops/s
BenchmarkRunner.benchmark          2        100  thrpt    5   1654.807 ±  14.934  ops/s
BenchmarkRunner.benchmark          2       1000  thrpt    5    170.718 ±   1.139  ops/s
BenchmarkRunner.benchmark          4          1  thrpt    5  45839.235 ± 362.435  ops/s
BenchmarkRunner.benchmark          4         10  thrpt    5   5896.294 ±  47.232  ops/s
BenchmarkRunner.benchmark          4        100  thrpt    5    699.316 ±   5.202  ops/s
BenchmarkRunner.benchmark          4       1000  thrpt    5     54.818 ±   0.973  ops/s
BenchmarkRunner.benchmark          8          1  thrpt    5  20218.785 ±  36.324  ops/s
BenchmarkRunner.benchmark          8         10  thrpt    5   3123.463 ±   7.248  ops/s
BenchmarkRunner.benchmark          8        100  thrpt    5    324.401 ±   4.183  ops/s
BenchmarkRunner.benchmark          8       1000  thrpt    5     27.847 ±   0.082  ops/s
```

### modified `AsciiTable::writeRepeated` (https://github.com/jp-berg/ascii-table/tree/performance/AsciiTable_writeRepeated_jmh)

```
Benchmark                  (numCols)  (numRows)   Mode  Cnt       Score       Error  Units
BenchmarkRunner.benchmark          2          1  thrpt    5  315228.799 ± 45604.900  ops/s
BenchmarkRunner.benchmark          2         10  thrpt    5   62918.142 ±   348.387  ops/s
BenchmarkRunner.benchmark          2        100  thrpt    5    6867.272 ±    41.383  ops/s
BenchmarkRunner.benchmark          2       1000  thrpt    5     635.620 ±     5.162  ops/s
BenchmarkRunner.benchmark          4          1  thrpt    5  191208.522 ±  8703.297  ops/s
BenchmarkRunner.benchmark          4         10  thrpt    5   31765.664 ±   114.372  ops/s
BenchmarkRunner.benchmark          4        100  thrpt    5    3466.429 ±    12.545  ops/s
BenchmarkRunner.benchmark          4       1000  thrpt    5     290.949 ±     2.925  ops/s
BenchmarkRunner.benchmark          8          1  thrpt    5  100651.367 ±  1221.314  ops/s
BenchmarkRunner.benchmark          8         10  thrpt    5   16487.830 ±    73.175  ops/s
BenchmarkRunner.benchmark          8        100  thrpt    5    1716.323 ±     7.292  ops/s
BenchmarkRunner.benchmark          8       1000  thrpt    5     160.368 ±     5.245  ops/s
```

To replicate the benchmark, please checkout the respective branches and run `BenchmarkRunner::main`.



