### PR TITLE
New AsciiTableCollector to convert streams into ASCII table

### DIFF
--- a/src/main/java/com/github/freva/asciitable/AsciiTableCollector.java
+++ b/src/main/java/com/github/freva/asciitable/AsciiTableCollector.java
@@ -1,0 +1,182 @@
+package com.github.freva.asciitable;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collector;
+
+/**
+ * Utility collector to convert a Stream of objects into an ASCII table String using {@link AsciiTable}.
+ *
+ * This implementation is optimized to map each element exactly once to a row (String[])
+ * while accumulating. It avoids creating an intermediate {@code List<T>} of original elements.
+ *
+ * @author oswaldo.bapvic.jr
+ * @since 1.13.0
+ */
+@NullMarked
+public final class AsciiTableCollector {
+    private AsciiTableCollector() {}
+
+    /**
+     * Returns a Collector that maps each stream element once to a String[] row (using the provided
+     * {@link ColumnData} getters), accumulates the rows and then renders the table.
+     *
+     * Example:
+     * <pre>{@code
+     * String table = people.stream().collect(AsciiTableCollectors.toAsciiTable(columns));
+     * }</pre>
+     *
+     * @param columns column definitions and getters used to extract cell values from stream elements
+     * @param <T> element type of the stream
+     * @return Collector producing the rendered table string
+     */
+    public static <T extends @Nullable Object> Collector<T, ?, String> toAsciiTable(List<ColumnData<T>> columns) {
+        Objects.requireNonNull(columns, "columns cannot be null");
+        final Column[] rawColumns = columns.toArray(new Column[0]);
+        final int cols = columns.size();
+
+        /**
+         * Accumulates mapped row data during collection.
+         *
+         * <p>This class stores the mapped rows (each row is a {@code String[]} of length {@code cols})
+         * in an {@link ArrayList}. It is intentionally simple:
+         * - add(T) maps an item to a row and appends it to the internal list;
+         * - combine(other) appends the other's rows to this accumulator to preserve encounter order.
+         *
+         * <p>Threading / parallel-safety:
+         * <ul>
+         *   <li>Instances of this accumulator are not themselves thread-safe. The {@link java.util.stream.Stream}
+         *       framework guarantees that each accumulator instance is only used by a single thread during the
+         *       accumulation phase (so you do not need additional synchronization inside the collector).</li>
+         *   <li>If you use parallel streams, the collector's combiner merges partial accumulators by appending
+         *       rows from one accumulator after another. For ordered streams, the stream implementation will
+         *       combine partial results in a way that preserves the encounter order in the final result.
+         *       If you require a strict, easily reasoned ordering with parallel execution, you can:
+         *       <ul>
+         *         <li>use a sequential stream (call {@code stream.sequential()}), or</li>
+         *         <li>ensure your source is ordered and accept the stream framework's ordering guarantees.</li>
+         *       </ul>
+         *   </li>
+         * </ul>
+         *
+         * <p>Memory: all rows are buffered (String[][]) because AsciiTable must compute column widths
+         * before rendering.
+         */
+        final class RowAccumulator {
+            final List<String[]> rows = new ArrayList<>();
+
+            void add(T item) {
+                String[] row = new String[cols];
+                for (int i = 0; i < cols; i++) {
+                    row[i] = columns.get(i).getCellValue(item);
+                }
+                rows.add(row);
+            }
+
+            RowAccumulator combine(RowAccumulator other) {
+                rows.addAll(other.rows);
+                return this;
+            }
+
+            String finish() {
+                String[][] data = rows.toArray(new String[rows.size()][]);
+                return AsciiTable.getTable(rawColumns, data);
+            }
+        }
+
+        return Collector.of(
+                RowAccumulator::new,
+                RowAccumulator::add,
+                (a, b) -> a.combine(b),
+                RowAccumulator::finish
+        );
+    }
+
+    /**
+     * Returns a Collector that maps each stream element once to a String[] row (using the provided
+     * {@link ColumnData} getters), accumulates the rows and then renders the table using the provided border.
+     *
+     * Example:
+     * <pre>{@code
+     * String table = people.stream().collect(AsciiTableCollectors
+     *                      .toAsciiTable(AsciiTable.FANCY_ASCII, columns));
+     * }</pre>
+     *
+     * @param border border character array (see {@link AsciiTable} constants)
+     * @param columns column definitions and getters used to extract cell values from stream elements
+     * @param <T> element type of the stream
+     * @return Collector producing the rendered table string
+     */
+    public static <T extends @Nullable Object> Collector<T, ?, String> toAsciiTable(@Nullable Character[] border, List<ColumnData<T>> columns) {
+        Objects.requireNonNull(border, "border cannot be null");
+        Objects.requireNonNull(columns, "columns cannot be null");
+        final Column[] rawColumns = columns.toArray(new Column[0]);
+        final int cols = columns.size();
+
+        /**
+         * Accumulates mapped row data during collection (border-aware finisher).
+         *
+         * See the documentation in the other overload's RowAccumulator for threading and memory notes.
+         */
+        class RowAccumulator {
+            final List<String[]> rows = new ArrayList<>();
+
+            void add(T item) {
+                String[] row = new String[cols];
+                for (int i = 0; i < cols; i++) {
+                    row[i] = columns.get(i).getCellValue(item);
+                }
+                rows.add(row);
+            }
+
+            RowAccumulator combine(RowAccumulator other) {
+                rows.addAll(other.rows);
+                return this;
+            }
+
+            String finish() {
+                String[][] data = rows.toArray(new String[rows.size()][]);
+                return AsciiTable.getTable(border, rawColumns, data);
+            }
+        }
+
+        return Collector.of(
+                RowAccumulator::new,
+                RowAccumulator::add,
+                (a, b) -> a.combine(b),
+                RowAccumulator::finish
+        );
+    }
+
+    /**
+     * Convenience varargs overload accepting {@link ColumnData} elements.
+     *
+     * @param columns column data varargs
+     * @param <T> element type of the stream
+     * @return Collector producing the rendered table string
+     */
+    @SafeVarargs
+    public static <T extends @Nullable Object> Collector<T, ?, String> toAsciiTable(ColumnData<T>... columns) {
+        Objects.requireNonNull(columns, "columns cannot be null");
+        return toAsciiTable(List.of(columns));
+    }
+
+    /**
+     * Convenience varargs overload accepting a border and {@link ColumnData} elements.
+     *
+     * @param border border character array
+     * @param columns column data varargs
+     * @param <T> element type of the stream
+     * @return Collector producing the rendered table string
+     */
+    @SafeVarargs
+    public static <T extends @Nullable Object> Collector<T, ?, String> toAsciiTable(@Nullable Character[] border, ColumnData<T>... columns) {
+        Objects.requireNonNull(border, "border cannot be null");
+        Objects.requireNonNull(columns, "columns cannot be null");
+        return toAsciiTable(border, List.of(columns));
+    }
+}

--- a/src/test/java/com/github/freva/asciitable/AsciiTableCollectorTest.java
+++ b/src/test/java/com/github/freva/asciitable/AsciiTableCollectorTest.java
@@ -1,0 +1,123 @@
+package com.github.freva.asciitable;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AsciiTableCollectorTest {
+
+    static class Person {
+        final int id;
+        final String name;
+        final int age;
+
+        Person(int id, String name, int age) {
+            this.id = id;
+            this.name = name;
+            this.age = age;
+        }
+    }
+
+    private List<Person> samplePeople() {
+        return Arrays.asList(
+                new Person(1, "Alice", 30),
+                new Person(2, "Bob", 25),
+                new Person(3, "Carol", 42)
+        );
+    }
+
+    @Test
+    public void collectsToTable_usingColumnDataList() {
+        List<Person> people = samplePeople();
+
+        List<ColumnData<Person>> columns = Arrays.asList(
+                new Column().with(p -> Integer.toString(p.id)),
+                new Column().header("Name").with(p -> p.name),
+                new Column().header("Age").dataAlign(HorizontalAlign.RIGHT).with(p -> Integer.toString(p.age))
+        );
+
+        String expected = AsciiTable.getTable(people, columns);
+        String actual = people.stream().collect(AsciiTableCollector.toAsciiTable(columns));
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectsToTable_usingBorderOverload() {
+        List<Person> people = samplePeople();
+
+        List<ColumnData<Person>> columns = Arrays.asList(
+                new Column().with(p -> Integer.toString(p.id)),
+                new Column().header("Name").with(p -> p.name),
+                new Column().header("Age").dataAlign(HorizontalAlign.RIGHT).with(p -> Integer.toString(p.age))
+        );
+
+        Character[] border = AsciiTable.BASIC_ASCII;
+        String expected = AsciiTable.getTable(border, people, columns);
+        String actual = people.stream().collect(AsciiTableCollector.toAsciiTable(border, columns));
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectsToTable_usingVarargsColumns() {
+        List<Person> people = samplePeople();
+
+        ColumnData<Person> c1 = new Column().with(p -> Integer.toString(p.id));
+        ColumnData<Person> c2 = new Column().header("Name").with(p -> p.name);
+        ColumnData<Person> c3 = new Column().header("Age").dataAlign(HorizontalAlign.RIGHT).with(p -> Integer.toString(p.age));
+
+        String expected = AsciiTable.getTable(people, Arrays.asList(c1, c2, c3));
+        String actual = people.stream().collect(AsciiTableCollector.toAsciiTable(c1, c2, c3));
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void collectsToTable_usingBorderVarargs() {
+        List<Person> people = samplePeople();
+
+        ColumnData<Person> c1 = new Column().with(p -> Integer.toString(p.id));
+        ColumnData<Person> c2 = new Column().header("Name").with(p -> p.name);
+        ColumnData<Person> c3 = new Column().header("Age").dataAlign(HorizontalAlign.RIGHT).with(p -> Integer.toString(p.age));
+
+        Character[] border = AsciiTable.BASIC_ASCII;
+
+        String expected = AsciiTable.getTable(border, people, Arrays.asList(c1, c2, c3));
+        String actual = people.stream().collect(AsciiTableCollector.toAsciiTable(border, c1, c2, c3));
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void parallelCollect_matchesSequential_and_getTable() {
+        // build an ordered source with unique ids to make testing deterministic
+        List<Person> people = IntStream.range(0, 2000) // larger N to encourage splitting
+                .mapToObj(i -> new Person(i, "Name" + i, 20 + (i % 50)))
+                .collect(Collectors.toList());
+
+        List<ColumnData<Person>> columns = List.of(
+                new Column().with(p -> Integer.toString(p.id)),
+                new Column().header("Name").with(p -> p.name),
+                new Column().header("Age").dataAlign(HorizontalAlign.RIGHT).with(p -> Integer.toString(p.age))
+        );
+
+        // expected using existing collection-based API (ordered)
+        String expected = AsciiTable.getTable(people, columns);
+
+        // actual using the optimized collector on a parallel stream
+        String actualParallel = people.parallelStream().collect(AsciiTableCollector.toAsciiTable(columns));
+        assertEquals(expected, actualParallel);
+
+        // also ensure parallel border overload matches
+        Character[] border = AsciiTable.BASIC_ASCII;
+        String expectedBorder = AsciiTable.getTable(border, people, columns);
+        String actualParallelBorder = people.parallelStream().collect(AsciiTableCollector.toAsciiTable(border, columns));
+        assertEquals(expectedBorder, actualParallelBorder);
+    }
+}


### PR DESCRIPTION
### Summary

This PR introduces a new class, `AsciiTableCollector`, which offers convenient and optimized `java.util.stream.Collector` implementations that render streams of domain objects into ASCII tables using the existing `AsciiTable`/`Column`/`ColumnData` APIs.

### Why
- **Common usage pattern:** users often have a `Stream<T>` (for example, to filter elements of a list before printing) and prefer to pass a `Collector` to `stream.collect(...)` to produce an ASCII table directly (without a new, intermediary list)
- **Performance improvement:** the typical prior approach was to collect the stream to a `List<T>` and then call `AsciiTable.getTable(list, columns)`. The new collector maps each stream element directly, avoiding the intermediate `List<T>`

### Usage example

#### Streaming from a large file (Files.lines):


```java
try (Stream<String> lines = Files.lines(Paths.get("big.csv"))) {
    String table = lines
        .skip(1) // skip header
        .map(line -> parseToPerson(line))
        .collect(AsciiTableCollectors.toAsciiTable(
            new Column<Person>().with(p -> Integer.toString(p.id)),
            new Column<Person>().header("Name").with(p -> p.name),
            new Column<Person>().header("Age").dataAlign(HorizontalAlign.RIGHT).with(p -> Integer.toString(p.age))
        ));

    System.out.println(table);
}
```

### Practical use-cases that benefit

- Rendering large CSV/TSV files line-by-line into tables without building domain object lists first.
- Building tables from generated or infinite sequences (with limit()).
- Quickly turning the output of a parallel processing stage into a table for logging or diagnostics.
- Integrating with stream-producing libraries (parquet readers, DB clients, reactive adapters that can expose Streams).

### What changed / Files added
- Added:
  - `src/main/java/com/github/freva/asciitable/AsciiTableCollectors.java`
- Tests:
  - `src/test/java/com/github/freva/asciitable/AsciiTableCollectorsTest.java`

### Backward compatibility
- No existing public APIs are removed or changed.
- `AsciiTableCollector` is additive; consumers can adopt it at will.
- Behavior for sequential streams is equivalent from the caller’s perspective.